### PR TITLE
Removed space from filename My Activity.json

### DIFF
--- a/google_takeout_to_sqlite/utils.py
+++ b/google_takeout_to_sqlite/utils.py
@@ -5,7 +5,7 @@ import datetime
 
 def save_my_activity(db, zf):
     my_activities = [
-        f.filename for f in zf.filelist if f.filename.endswith("My Activity.json")
+        f.filename for f in zf.filelist if f.filename.endswith("MyActivity.json")
     ]
     created = "my_activity" not in db.table_names()
     for filename in my_activities:


### PR DESCRIPTION
File name from google takeout has no space. The code only runs without error if filename is "MyActivity.json" and not "My Activity.json". Is it a new change by Google?